### PR TITLE
mergeFileList 작성 안했을 때 Nullpoint에러

### DIFF
--- a/src/com/miconblog/jstools/taglib/MergeTag.java
+++ b/src/com/miconblog/jstools/taglib/MergeTag.java
@@ -44,7 +44,7 @@ public class MergeTag extends BodyTagSupport {
 				// 디버그 모드가 아니고, 머지 파일이 있는 경우
 				content = includeStaticString(mergedFile);
 
-			} else if( isDebug() == true && mergeListFile !=null && existListFile(mergeListFile) ){
+			} else if( isDebug() == true && mergeListFile != null && existListFile(mergeListFile) ){
 				
 				LOGGER.info("Debug Mode");
 				

--- a/src/com/miconblog/jstools/taglib/MergeTag.java
+++ b/src/com/miconblog/jstools/taglib/MergeTag.java
@@ -44,7 +44,7 @@ public class MergeTag extends BodyTagSupport {
 				// 디버그 모드가 아니고, 머지 파일이 있는 경우
 				content = includeStaticString(mergedFile);
 
-			} else if( isDebug() == true && existListFile(mergeListFile) ){
+			} else if( isDebug() == true && mergeListFile !=null && existListFile(mergeListFile) ){
 				
 				LOGGER.info("Debug Mode");
 				


### PR DESCRIPTION
## 변경내용
* 아래와 같이 사용했을 때 Nullpoint에러가 발생하는 문제를 해결했습니다.
* `mergeFileList="builder/mergelist.txt"` <- 이부분을 작성하지 않았을 때의 문제임
```
<jstools:merge mergedFile="/js/release/app.js" debug="Y">
</jstools:merge>
```
